### PR TITLE
feat(examples): Updates ess-dive example and add Python .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,93 @@
-# Ignore files that are generated whenever a developer `pip install`s this package
-# from a local clone of this repository (e.g. `pip install /path/to/bertron-schema`),
-# rather than via its Git URL or—once it gets published to PyPI—via PyPI.
-/src/*.egg-info/
-/build/
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#   Usually these files are written by a python script from a template
+#   before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Sphinx documentation
+docs/_build/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc

--- a/src/sample_data/valid/Entity-ess-dive-example-00001.yaml
+++ b/src/sample_data/valid/Entity-ess-dive-example-00001.yaml
@@ -3,12 +3,11 @@ coordinates:
   latitude: 65.162309
   longitude: -164.819851
 entity_type:
-  - unspecified
-description: Maps of land surface phenology derived from PlanetScope data,
+  - site
+name: Maps of land surface phenology derived from PlanetScope data,
   2018-2022, Teller, Kougarok, and Council, Seward Peninsula
 id: doi:10.15485/2441497
-name: NGEE Arctic Kougarok Site, Mile Marker 64, Alaska
+description: NGEE Arctic Kougarok Site, Mile Marker 64, Alaska
 alt_ids:
   - NGA547
-part_of_collection: []
 uri: https://data.ess-dive.lbl.gov/view/doi:10.15485/2441497

--- a/src/sample_data/valid/Entity-ess-dive-example-00002.yaml
+++ b/src/sample_data/valid/Entity-ess-dive-example-00002.yaml
@@ -3,12 +3,11 @@ coordinates:
   latitude: 64.735492
   longitude: -165.95039
 entity_type:
-  - unspecified
-description: Maps of land surface phenology derived from PlanetScope data,
+  - site
+name: Maps of land surface phenology derived from PlanetScope data,
   2018-2022, Teller, Kougarok, and Council, Seward Peninsula
 id: doi:10.15485/2441497
-name: NGEE Arctic Teller Site, Mile Marker 27, Alaska
+description: NGEE Arctic Teller Site, Mile Marker 27, Alaska
 alt_ids:
   - NGA547
-part_of_collection: []
 uri: https://data.ess-dive.lbl.gov/view/doi:10.15485/2441497

--- a/src/sample_data/valid/Entity-ess-dive-example-00003.yaml
+++ b/src/sample_data/valid/Entity-ess-dive-example-00003.yaml
@@ -3,12 +3,11 @@ coordinates:
   latitude: 64.847286
   longitude: -163.71993600000002
 entity_type:
-  - unspecified
-description: Maps of land surface phenology derived from PlanetScope data,
+  - site
+name: Maps of land surface phenology derived from PlanetScope data,
   2018-2022, Teller, Kougarok, and Council, Seward Peninsula
 id: doi:10.15485/2441497
-name: NGEE Arctic Council Site, Mile Marker 71, Alaska
+description: NGEE Arctic Council Site, Mile Marker 71, Alaska
 alt_ids:
   - NGA547
-part_of_collection: []
 uri: https://data.ess-dive.lbl.gov/view/doi:10.15485/2441497


### PR DESCRIPTION
This PR only partially addresses the issue due to the fact that Entity does not allow null coordinates. However, the other requriements have been addressed and are worth merging.

- Adds a .gitignore file to prevent committing Python build artifacts and cache directories (such as __pycache__ and egg-info), keeping the repository clean and avoiding unnecessary files in version control.
- Updates the entity_type and description fields in the ESS-DIVE JSON example to improve data accuracy and consistency.
- This issue will not be fully addressed until Entity allows null
  coordinates

Ref #57