### PR TITLE
Make sample data accessible via `import`-ed Python package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore files that are generated whenever a developer `pip install`s this package
+# from a local clone of this repository (e.g. `pip install /path/to/bertron-schema`),
+# rather than via its Git URL or—once it gets published to PyPI—via PyPI.
+/src/*.egg-info/
+/build/

--- a/src/sample_data/__init__.py
+++ b/src/sample_data/__init__.py
@@ -1,0 +1,66 @@
+"""Sample data, and functions that facilitate accessing that sample data."""
+
+import json
+from importlib import resources
+from typing import Any
+
+import yaml
+
+
+def get_sample_data_text(file_path: str, encoding: str = "utf-8") -> str:
+    """Get the text content of a sample data file.
+
+    Args:
+        file_path: The path to the sample data file, relative to the `sample_data/` directory.
+        encoding: The text encoding to use when reading the file.
+
+    Returns:
+        The text content of the specified sample data file.
+
+    References:
+    - https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files
+    - https://docs.python.org/3/library/importlib.resources.html#importlib.resources.as_file
+    - https://docs.python.org/3/library/importlib.resources.abc.html#importlib.resources.abc.Traversable
+
+    """
+    # Define the path someone could use to `import` the Python package _containing_ the
+    # `invalid/` and `valid/` directories (e.g. `import {something}`); which, currently,
+    # happens to be the directory containing this `__init__.py` file.
+    package_import_path = "sample_data"
+
+    # Create a `Traversable` object that can be passed to the `resources.as_file()` function.
+    traversable_resource_container = resources.files(package_import_path).joinpath(file_path)
+
+    # Get a handle for the asset file (as a `Path` object).
+    with resources.as_file(traversable_resource_container) as path:
+
+        # Return the text content of the file.
+        return path.read_text(encoding=encoding)
+
+
+def get_sample_data(file_path: str, encoding: str = "utf-8") -> Any:  # noqa: ANN401
+    """Get a Python value representing the content of a JSON/YAML-formatted sample data file.
+
+    Args:
+        file_path: The path to the sample data file, relative to the `sample_data/` directory.
+        encoding: The text encoding to use when reading the file.
+
+    Returns:
+        The content of the specified sample data file, parsed into a Python value
+        (in practice this is typically a dictionary or list).
+
+    """
+    # Determine which parsing function we will use, based upon the file's extension.
+    if file_path.endswith((".yaml", ".yml")):
+        parse = yaml.safe_load
+    elif file_path.endswith(".json"):
+        parse = json.loads
+    else:
+        # Raise an error indicating that we don't support files having that extension.
+        # Note: The `!r` after the in-string variable below calls `repr()` on the value.
+        #       Since the value is a string, the string will appear wrapped in quotes.
+        msg = f"File extension suggest an unsupported file type: {file_path!r}"
+        raise ValueError(msg)
+
+    text = get_sample_data_text(file_path, encoding=encoding)
+    return parse(text)


### PR DESCRIPTION
On this branch, I implemented a function named `get_sample_data` that people (people that `import` this Python package; e.g. `ber-data/bertron` developers) can use to access the sample data residing in this repository.

### Details

Those people can use `get_sample_data` to get the sample data as a Python data structure (for all existing sample data files, that data structure is a dictionary); or they can use the lower-level `get_sample_data_text` function to get the "raw" text of a sample data file.

### Notes

The caller is responsible for specifying the path to the sample data file. A future enhancement could be to include a function that returns a catalog of available sample data.

### Demo

Here's a copy/paste from my interactive Python shell (`ptpython`) as I invoke the `get_sample_data` function:

```py
>>> from sample_data import get_sample_data, get_sample_data_text
>>> get_sample_data("invalid/Dataset-001.yaml")
{'id': '001', 'name': 'foo bar', 'primary_email': 'not-an-email-address', 'age_in_years': 33}

>>> get_sample_data("valid/Dataset-001.yaml")
{'id': '001', 'name': 'foo bar', 'primary_email': 'foo.bar@example.com', 'age_in_years': 33}

>>> get_sample_data("valid/emsl-example.json")
{'ber_data_source': 'MONET', 'coordinates': {'latitude': 39.0855, 'longitude': -96.5845, 'altitude': None, 'depth': None, 'elevation': {'numeric_value': 387.08, 'unit': 'm'}}, 'entity_type': ['sample'], 'description': None, 'id': 'fca44f53-14cb-42cf-bc9a-73af11a80c8b', 'name': 'MONet Core 60933_19_BOTTOM', 'alt_ids': None, 'alt_names': None, 'part_of_collection': None, 'uri': 'https://sc-data.emsl.pnnl.gov/monet', 'properties': [{'attribute': {'id': 'MIXS:0000332', 'label': 'soil_type'}, 'raw_value': 'Mollisol'}, {'attribute': {'id': 'MIXS:0000011', 'label': 'collection_date'}, 'raw_value': '2023-10-23 15:23:00'}, {'attribute': {'label': 'ecoregion'}, 'raw_value': 'prairie_peninsula'}, {'attribute': {'label': 'toc_avg'}, 'raw_value': '1324.18 mg per kg', 'unit': 'mg per kg', 'numeric_value': 1324.18}, {'attribute': {'label': 'tn_avg'}, 'raw_value': '39.34 mg per kg', 'unit': 'mg per kg', 'numeric_value': 39.34}]}

>>>
```