### PR TITLE
DateTimeValue and some attr/value reorganisation

### DIFF
--- a/src/schema/datamodel/bertron_schema_pydantic.py
+++ b/src/schema/datamodel/bertron_schema_pydantic.py
@@ -156,7 +156,9 @@ class AttributeValue(ConfiguredBaseModel):
          'from_schema': 'https://w3id.org/ber-data/bertron_types'})
 
     attribute: Attribute = Field(default=..., description="""The attribute being represented.""", json_schema_extra = { "linkml_meta": {'alias': 'attribute', 'domain_of': ['AttributeValue']} })
-    raw_value: Optional[str] = Field(default=None, description="""The raw value.""", json_schema_extra = { "linkml_meta": {'alias': 'raw_value', 'domain_of': ['AttributeValue', 'NamedQuantityValue']} })
+    raw_value: Optional[str] = Field(default=None, description="""The value that was specified for an annotation in raw form, i.e. a string. E.g. \"2 cm\" or \"2-4 cm\"""", json_schema_extra = { "linkml_meta": {'alias': 'raw_value',
+         'domain_of': ['AttributeValue'],
+         'mappings': ['nmdc:raw_value']} })
 
 
 class Attribute(ConfiguredBaseModel):
@@ -173,63 +175,35 @@ class Attribute(ConfiguredBaseModel):
 
 class QuantityValue(AttributeValue):
     """
-    A simple quantity, e.g. 2cm
+    A simple quantity, e.g. 2cm.
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'nmdc:QuantityValue',
          'from_schema': 'https://w3id.org/ber-data/bertron_types',
          'mappings': ['schema:QuantityValue'],
-         'slot_usage': {'numeric_value': {'description': 'The number part of the '
-                                                         'quantity',
-                                          'name': 'numeric_value'},
-                        'raw_value': {'description': 'Unnormalized atomic string '
+         'slot_usage': {'raw_value': {'description': 'Unnormalized atomic string '
                                                      'representation, suggested syntax '
                                                      '{number} {unit}',
-                                      'name': 'raw_value'},
-                        'unit': {'description': 'The unit of the quantity',
-                                 'name': 'unit'}}})
+                                      'name': 'raw_value'}}})
 
     maximum_numeric_value: Optional[float] = Field(default=None, description="""The maximum value part, expressed as number, of the quantity value when the value covers a range.""", json_schema_extra = { "linkml_meta": {'alias': 'maximum_numeric_value',
-         'domain_of': ['QuantityValue', 'NamedQuantityValue'],
+         'domain_of': ['QuantityValue'],
          'is_a': 'numeric_value',
          'mappings': ['nmdc:maximum_numeric_value']} })
     minimum_numeric_value: Optional[float] = Field(default=None, description="""The minimum value part, expressed as number, of the quantity value when the value covers a range.""", json_schema_extra = { "linkml_meta": {'alias': 'minimum_numeric_value',
-         'domain_of': ['QuantityValue', 'NamedQuantityValue'],
+         'domain_of': ['QuantityValue'],
          'is_a': 'numeric_value',
          'mappings': ['nmdc:minimum_numeric_value']} })
-    numeric_value: Optional[float] = Field(default=None, description="""The number part of the quantity""", json_schema_extra = { "linkml_meta": {'alias': 'numeric_value',
-         'domain_of': ['QuantityValue', 'NamedQuantityValue'],
-         'mappings': ['nmdc:numeric_value', 'qud:quantityValue', 'schema:value']} })
-    unit: Optional[str] = Field(default=None, description="""The unit of the quantity""", json_schema_extra = { "linkml_meta": {'alias': 'unit',
-         'aliases': ['scale'],
-         'domain_of': ['QuantityValue', 'NamedQuantityValue'],
-         'mappings': ['nmdc:unit', 'qud:unit', 'schema:unitCode']} })
-    attribute: Attribute = Field(default=..., description="""The attribute being represented.""", json_schema_extra = { "linkml_meta": {'alias': 'attribute', 'domain_of': ['AttributeValue']} })
-    raw_value: Optional[str] = Field(default=None, description="""Unnormalized atomic string representation, suggested syntax {number} {unit}""", json_schema_extra = { "linkml_meta": {'alias': 'raw_value', 'domain_of': ['AttributeValue', 'NamedQuantityValue']} })
-
-
-class NamedQuantityValue(ConfiguredBaseModel):
-    """
-    A quantity value where the attribute is already specified.
-    """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/ber-data/bertron_types'})
-
-    maximum_numeric_value: Optional[float] = Field(default=None, description="""The maximum value part, expressed as number, of the quantity value when the value covers a range.""", json_schema_extra = { "linkml_meta": {'alias': 'maximum_numeric_value',
-         'domain_of': ['QuantityValue', 'NamedQuantityValue'],
-         'is_a': 'numeric_value',
-         'mappings': ['nmdc:maximum_numeric_value']} })
-    minimum_numeric_value: Optional[float] = Field(default=None, description="""The minimum value part, expressed as number, of the quantity value when the value covers a range.""", json_schema_extra = { "linkml_meta": {'alias': 'minimum_numeric_value',
-         'domain_of': ['QuantityValue', 'NamedQuantityValue'],
-         'is_a': 'numeric_value',
-         'mappings': ['nmdc:minimum_numeric_value']} })
-    numeric_value: Optional[float] = Field(default=None, description="""Links a quantity value to a number""", json_schema_extra = { "linkml_meta": {'alias': 'numeric_value',
-         'domain_of': ['QuantityValue', 'NamedQuantityValue'],
+    numeric_value: Optional[float] = Field(default=None, description="""The numerical part of a quantity value.""", json_schema_extra = { "linkml_meta": {'alias': 'numeric_value',
+         'domain_of': ['QuantityValue'],
          'mappings': ['nmdc:numeric_value', 'qud:quantityValue', 'schema:value']} })
     unit: Optional[str] = Field(default=None, description="""Links a QuantityValue to a unit. Units should be taken from the UCUM unit collection or the Unit Ontology.""", json_schema_extra = { "linkml_meta": {'alias': 'unit',
          'aliases': ['scale'],
-         'domain_of': ['QuantityValue', 'NamedQuantityValue'],
-         'mappings': ['nmdc:unit', 'qud:unit', 'schema:unitCode']} })
-    raw_value: Optional[str] = Field(default=None, description="""The value that was specified for an annotation in raw form, i.e. a string. E.g. \"2 cm\" or \"2-4 cm\"""", json_schema_extra = { "linkml_meta": {'alias': 'raw_value',
-         'domain_of': ['AttributeValue', 'NamedQuantityValue'],
+         'domain_of': ['QuantityValue'],
+         'mappings': ['nmdc:unit', 'qud:unit', 'schema:unitCode', 'UO:0000000']} })
+    unit_cv_id: Optional[str] = Field(default=None, description="""The unit of the quantity, expressed as a CURIE from the Unit Ontology.""", json_schema_extra = { "linkml_meta": {'alias': 'unit_cv_id', 'domain_of': ['QuantityValue']} })
+    attribute: Attribute = Field(default=..., description="""The attribute being represented.""", json_schema_extra = { "linkml_meta": {'alias': 'attribute', 'domain_of': ['AttributeValue']} })
+    raw_value: Optional[str] = Field(default=None, description="""Unnormalized atomic string representation, suggested syntax {number} {unit}""", json_schema_extra = { "linkml_meta": {'alias': 'raw_value',
+         'domain_of': ['AttributeValue'],
          'mappings': ['nmdc:raw_value']} })
 
 
@@ -240,10 +214,38 @@ class TextValue(AttributeValue):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'nmdc:TextValue',
          'from_schema': 'https://w3id.org/ber-data/bertron_types'})
 
-    value: Optional[str] = Field(default=None, description="""The value, as a text string.""", json_schema_extra = { "linkml_meta": {'alias': 'value', 'domain_of': ['TextValue']} })
+    value: Optional[str] = Field(default=None, description="""The value, as a text string.""", json_schema_extra = { "linkml_meta": {'alias': 'value', 'domain_of': ['TextValue', 'DateTimeValue']} })
     value_cv_id: Optional[str] = Field(default=None, description="""For values that are in a controlled vocabulary (CV), this attribute should capture the controlled vocabulary ID for the value.""", json_schema_extra = { "linkml_meta": {'alias': 'value_cv_id', 'domain_of': ['TextValue']} })
     attribute: Attribute = Field(default=..., description="""The attribute being represented.""", json_schema_extra = { "linkml_meta": {'alias': 'attribute', 'domain_of': ['AttributeValue']} })
-    raw_value: Optional[str] = Field(default=None, description="""The raw value.""", json_schema_extra = { "linkml_meta": {'alias': 'raw_value', 'domain_of': ['AttributeValue', 'NamedQuantityValue']} })
+    raw_value: Optional[str] = Field(default=None, description="""The value that was specified for an annotation in raw form, i.e. a string. E.g. \"2 cm\" or \"2-4 cm\"""", json_schema_extra = { "linkml_meta": {'alias': 'raw_value',
+         'domain_of': ['AttributeValue'],
+         'mappings': ['nmdc:raw_value']} })
+
+
+class DateTimeValue(AttributeValue):
+    """
+    A date or date and time value.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'nmdc:DateTimeValue',
+         'from_schema': 'https://w3id.org/ber-data/bertron_types',
+         'slot_usage': {'value': {'description': 'The date or date/time value, '
+                                                 'expressed in ISO 8601-compatible '
+                                                 'form. Dates should be expressed as '
+                                                 'YYYY-MM-DD; times should be '
+                                                 'expressed as HH:MM:SS with optional '
+                                                 'milliseconds and an indication of '
+                                                 'the timezone.',
+                                  'examples': [{'value': '2025-11-09'},
+                                               {'value': '2025-09-16T22:48:54Z'}],
+                                  'name': 'value'}}})
+
+    value: Optional[str] = Field(default=None, description="""The date or date/time value, expressed in ISO 8601-compatible form. Dates should be expressed as YYYY-MM-DD; times should be expressed as HH:MM:SS with optional milliseconds and an indication of the timezone.""", json_schema_extra = { "linkml_meta": {'alias': 'value',
+         'domain_of': ['TextValue', 'DateTimeValue'],
+         'examples': [{'value': '2025-11-09'}, {'value': '2025-09-16T22:48:54Z'}]} })
+    attribute: Attribute = Field(default=..., description="""The attribute being represented.""", json_schema_extra = { "linkml_meta": {'alias': 'attribute', 'domain_of': ['AttributeValue']} })
+    raw_value: Optional[str] = Field(default=None, description="""The value that was specified for an annotation in raw form, i.e. a string. E.g. \"2 cm\" or \"2-4 cm\"""", json_schema_extra = { "linkml_meta": {'alias': 'raw_value',
+         'domain_of': ['AttributeValue'],
+         'mappings': ['nmdc:raw_value']} })
 
 
 class Entity(ConfiguredBaseModel):
@@ -393,8 +395,8 @@ class DataCollection(ConfiguredBaseModel):
 AttributeValue.model_rebuild()
 Attribute.model_rebuild()
 QuantityValue.model_rebuild()
-NamedQuantityValue.model_rebuild()
 TextValue.model_rebuild()
+DateTimeValue.model_rebuild()
 Entity.model_rebuild()
 Coordinates.model_rebuild()
 Name.model_rebuild()

--- a/src/schema/jsonschema/bertron_schema.json
+++ b/src/schema/jsonschema/bertron_schema.json
@@ -122,6 +122,35 @@
             "title": "DataCollection",
             "type": "object"
         },
+        "DateTimeValue": {
+            "additionalProperties": false,
+            "description": "A date or date and time value.",
+            "properties": {
+                "attribute": {
+                    "$ref": "#/$defs/Attribute",
+                    "description": "The attribute being represented."
+                },
+                "raw_value": {
+                    "description": "The value that was specified for an annotation in raw form, i.e. a string. E.g. \"2 cm\" or \"2-4 cm\"",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "value": {
+                    "description": "The date or date/time value, expressed in ISO 8601-compatible form. Dates should be expressed as YYYY-MM-DD; times should be expressed as HH:MM:SS with optional milliseconds and an indication of the timezone.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "attribute"
+            ],
+            "title": "DateTimeValue",
+            "type": "object"
+        },
         "Entity": {
             "additionalProperties": false,
             "description": "An object retrieved by BERtron from a BER data API.",
@@ -277,52 +306,9 @@
             "title": "NameType",
             "type": "string"
         },
-        "NamedQuantityValue": {
-            "additionalProperties": false,
-            "description": "A quantity value where the attribute is already specified.",
-            "properties": {
-                "maximum_numeric_value": {
-                    "description": "The maximum value part, expressed as number, of the quantity value when the value covers a range.",
-                    "type": [
-                        "number",
-                        "null"
-                    ]
-                },
-                "minimum_numeric_value": {
-                    "description": "The minimum value part, expressed as number, of the quantity value when the value covers a range.",
-                    "type": [
-                        "number",
-                        "null"
-                    ]
-                },
-                "numeric_value": {
-                    "description": "Links a quantity value to a number",
-                    "type": [
-                        "number",
-                        "null"
-                    ]
-                },
-                "raw_value": {
-                    "description": "The value that was specified for an annotation in raw form, i.e. a string. E.g. \"2 cm\" or \"2-4 cm\"",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
-                "unit": {
-                    "description": "Links a QuantityValue to a unit. Units should be taken from the UCUM unit collection or the Unit Ontology.",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                }
-            },
-            "title": "NamedQuantityValue",
-            "type": "object"
-        },
         "QuantityValue": {
             "additionalProperties": false,
-            "description": "A simple quantity, e.g. 2cm",
+            "description": "A simple quantity, e.g. 2cm.",
             "properties": {
                 "attribute": {
                     "$ref": "#/$defs/Attribute",
@@ -343,7 +329,7 @@
                     ]
                 },
                 "numeric_value": {
-                    "description": "The number part of the quantity",
+                    "description": "The numerical part of a quantity value.",
                     "type": [
                         "number",
                         "null"
@@ -357,7 +343,14 @@
                     ]
                 },
                 "unit": {
-                    "description": "The unit of the quantity",
+                    "description": "Links a QuantityValue to a unit. Units should be taken from the UCUM unit collection or the Unit Ontology.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "unit_cv_id": {
+                    "description": "The unit of the quantity, expressed as a CURIE from the Unit Ontology.",
                     "type": [
                         "string",
                         "null"
@@ -379,7 +372,7 @@
                     "description": "The attribute being represented."
                 },
                 "raw_value": {
-                    "description": "The raw value.",
+                    "description": "The value that was specified for an annotation in raw form, i.e. a string. E.g. \"2 cm\" or \"2-4 cm\"",
                     "type": [
                         "string",
                         "null"

--- a/src/schema/linkml/bertron_types.yaml
+++ b/src/schema/linkml/bertron_types.yaml
@@ -15,8 +15,13 @@ default_range: string
 
 slots:
 
+  attribute:
+    description: The attribute being represented.
+    range: Attribute
+    required: true
+
   numeric_value:
-    description: Links a quantity value to a number
+    description: The numerical part of a quantity value.
     range: float
     mappings:
       - nmdc:numeric_value
@@ -42,14 +47,27 @@ slots:
       - nmdc:raw_value
 
   unit:
-    description: Links a QuantityValue to a unit. Units should be taken from the UCUM unit collection or the Unit Ontology.
+    description: Links a QuantityValue to a unit. Units should be taken from the UCUM unit collection or a term from the Unit Ontology.
     aliases:
       - scale
-    range: unit
+    range: string
     mappings:
       - nmdc:unit
       - qud:unit
       - schema:unitCode
+      - UO:0000000
+
+  unit_cv_id:
+    description: The unit of the quantity, expressed as a CURIE from the Unit Ontology.
+    range: curie
+
+  value:
+    description: The value, as a text string.
+    range: string
+
+  value_cv_id:
+    description: For values that are in a controlled vocabulary (CV), this attribute should capture the controlled vocabulary ID for the value.
+    range: curie
 
 classes:
 
@@ -61,14 +79,9 @@ classes:
     class_uri: nmdc:AttributeValue
     description: >-
       The value for any value of attribute for an entity. This object can hold both the un-normalized atomic value and the structured value.
-    attributes:
-      attribute:
-        description: The attribute being represented.
-        range: Attribute
-        required: true
-      raw_value:
-        range: string
-        description: The raw value.
+    slots:
+    - attribute
+    - raw_value
 
   Attribute:
     description: A domain, measurement, attribute, property, or any descriptor for additional properties to be added to an entity. Where available, please use OBO Foundry ontologies or other controlled vocabularies for attributes; the label should be the term name from the ontology and the id should be the fully-qualified CURIE.
@@ -86,40 +99,48 @@ classes:
   QuantityValue:
     class_uri: nmdc:QuantityValue
     is_a: AttributeValue
-    description: A simple quantity, e.g. 2cm
+    description: A simple quantity, e.g. 2cm.
     slots:
       - maximum_numeric_value
       - minimum_numeric_value
       - numeric_value
       - unit
+      - unit_cv_id
     slot_usage:
       raw_value:
         description: Unnormalized atomic string representation, suggested syntax {number} {unit}
-      unit:
-        description: The unit of the quantity
-      numeric_value:
-        description: The number part of the quantity
     mappings:
       - schema:QuantityValue
 
   NamedQuantityValue:
+    is_a: AttributeValue
     description: A quantity value where the attribute is already specified.
     slots:
-      - maximum_numeric_value
-      - minimum_numeric_value
       - numeric_value
       - unit
-      - raw_value
 
   TextValue:
     class_uri: nmdc:TextValue
     is_a: AttributeValue
     description: A quality, described using a text string.
-    attributes:
+    slots:
+    - value
+    - value_cv_id
+
+  DateTimeValue:
+    class_uri: nmdc:DateTimeValue
+    is_a: AttributeValue
+    description: A date or date and time value.
+    slots:
+    - value
+    slot_usage:
       value:
-        description: The value, as a text string.
-      value_cv_id:
-        description: For values that are in a controlled vocabulary (CV), this attribute should capture the controlled vocabulary ID for the value.
+        description: The date or date/time value, expressed in ISO 8601-compatible form. Dates should be expressed as YYYY-MM-DD; times should be expressed as HH:MM:SS with optional milliseconds and an indication of the timezone.
+        # TODO: add pattern for ISO 8601 timestamps
+        examples:
+        - value: "2025-11-09"
+        - value: "2025-09-16T22:48:54Z"
+
 
 types:
   decimal degree:
@@ -128,10 +149,3 @@ types:
     base: float
     see_also:
       - https://en.wikipedia.org/wiki/Decimal_degrees
-
-  unit:
-    base: str
-    uri: xsd:string
-    mappings:
-      - qud:Unit
-      - UO:0000000

--- a/src/schema/linkml/bertron_types.yaml
+++ b/src/schema/linkml/bertron_types.yaml
@@ -47,7 +47,7 @@ slots:
       - nmdc:raw_value
 
   unit:
-    description: Links a QuantityValue to a unit. Units should be taken from the UCUM unit collection or a term from the Unit Ontology.
+    description: Links a QuantityValue to a unit. Units should be taken from the UCUM unit collection or the Unit Ontology.
     aliases:
       - scale
     range: string
@@ -111,13 +111,6 @@ classes:
         description: Unnormalized atomic string representation, suggested syntax {number} {unit}
     mappings:
       - schema:QuantityValue
-
-  NamedQuantityValue:
-    is_a: AttributeValue
-    description: A quantity value where the attribute is already specified.
-    slots:
-      - numeric_value
-      - unit
 
   TextValue:
     class_uri: nmdc:TextValue


### PR DESCRIPTION
- adds a new type of attribute-value for representing date times
- reorganises the schema a bit to make more use of slots
- removes a redundant `unit` type
- removes the class `NamedQuantityValue`, which was used for some attributes that have now been removed (depth, altitude, elevation).

If this is approved, I will update the sample data to match this format.

See also https://github.com/ber-data/bertron-schema/issues/62